### PR TITLE
fix(types): fix wrong export name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,10 @@ export interface MetricsPluginOptions extends Options {
     };
 }
 
-export const trapsPluginCallback: FastifyPluginCallback<MetricsPluginOptions>;
-export const trapsPluginAsync: FastifyPluginAsync<MetricsPluginOptions>;
+export const MetricsPluginCallback: FastifyPluginCallback<MetricsPluginOptions>;
+export const MetricsPluginAsync: FastifyPluginAsync<MetricsPluginOptions>;
 
-export default trapsPluginCallback;
+export default MetricsPluginCallback;
 
 declare module 'fastify' {
     interface FastifyInstance {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,17 @@
 import { expectType } from 'tsd';
 
-import Fastify from 'fastify';
+import Fastify, { FastifyPluginCallback, FastifyPluginAsync } from 'fastify';
 import Client from '@immobiliarelabs/dats';
 import { Sampler } from '@dnlup/doc';
-import plugin from './index';
+import plugin, {
+    MetricsPluginCallback,
+    MetricsPluginAsync,
+    MetricsPluginOptions,
+} from './index';
+
+expectType<FastifyPluginCallback<MetricsPluginOptions>>(plugin);
+expectType<FastifyPluginCallback<MetricsPluginOptions>>(MetricsPluginCallback);
+expectType<FastifyPluginAsync<MetricsPluginOptions>>(MetricsPluginAsync);
 
 const fastify = Fastify();
 


### PR DESCRIPTION
Plugin init functions had a wrong name.

BREAKING CHANGE: the plugin init functions have different names.