### PR TITLE
Allow to override the routes prefix in the label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 If you write your services and apps using `Fastify` and also use `statsd`, this plugin might be for you!
 
-It automatically collects Node.js process metrics along with routes hit count, timings and errors and uses the [`dats`](https://github.com/immobiliare/dats) client to send them to a `stasd` collector.
+It automatically collects Node.js process metrics along with routes hit count, timings and errors and uses the [`Dats`](https://github.com/immobiliare/dats) client to send them to a `stasd` collector.
 
 It supports Fastify versions `>=3.0.0`.
 
@@ -27,9 +27,28 @@ It supports Fastify versions `>=3.0.0`.
     -   [Notes](#notes)
 -   [Metrics collected](#metrics-collected)
 -   [Decorators](#decorators)
+    -   [Fastify decorators](#fastify-decorators)
+        -   [`metricsNamespace`](#metricsnamespace)
+        *   [`metricsRoutesPrefix`](#metricsroutesprefix)
+        *   [`metricsClient`](#metricsclient)
+        *   [`doc`](#doc)
+        *   [`hrtime2ns`](#hrtime2ns)
+        *   [`hrtime2ms`](#hrtime2ms)
+        *   [`hrtime2s`](#hrtime2s)
+    -   [Request and Reply decorators](#request-and-reply-decorators)
+        -   [`sendTimingMetric(name[, value])`](#sendtimingmetricname-value)
+        -   [`sendCounterMetric(name[, value])`](#sendcountermetricname-value)
+        -   [`sendGaugeMetric(name, value)`](#sendgaugemetricname-value)
+        -   [`sendSetMetric(name, value)`](#sendsetmetricname-value)
 -   [Hooks](#hooks)
 -   [API](#api)
     -   [Configuration `options`](#configuration-options)
+        -   [Routes labels generation modes](#routes-labels-generation-modes)
+            -   [computedPrefix](#computedprefix)
+            *   [`static`](#static)
+                -   [`getLabel(prefix, options)`](#getlabelprefix-options)
+            *   [`dynamic`](#dynamic)
+                -   [`getLabel(request, reply)`](#getlabelrequest-reply)
 -   [Powered Apps](#powered-apps)
 -   [Support & Contribute](#support--contribute)
 -   [License](#license)
@@ -92,37 +111,102 @@ See https://github.com/fastify/fastify/blob/master/docs/Routes.md#config.
 
 These are the metrics that are collected automatically.
 
-| Name                                                    | Type      | Unit of measure                 | Description                                    |
-| :------------------------------------------------------ | :-------- | :------------------------------ | :--------------------------------------------- |
-| `<METRICS_NAMESPACE>.process.cpu`                       | `gauge`   | percentage                      | process cpu usage                              |
-| `<METRICS_NAMESPACE>.process.mem.external`              | `gauge`   | bytes                           | process external memory                        |
-| `<METRICS_NAMESPACE>.process.mem.rss`                   | `gauge`   | bytes                           | process rss memory                             |
-| `<METRICS_NAMESPACE>.process.mem.heapUsed`              | `gauge`   | bytes                           | process heap used memory                       |
-| `<METRICS_NAMESPACE>.process.mem.heapTotal`             | `gauge`   | bytes                           | process heap total memory                      |
-| `<METRICS_NAMESPACE>.process.eventLoopDelay`            | `gauge`   | milliseconds                    | process event loop delay                       |
-| `<METRICS_NAMESPACE>.process.eventLoopUtilization`      | `gauge`   | absolute number between 0 and 1 | process event loop utilization                 |
-| `<METRICS_NAMESPACE>.api.<routeId>.requests`            | `counter` | unit                            | requests count per service route               |
-| `<METRICS_NAMESPACE>.api.<routeId>.errors.<statusCode>` | `counter` | unit                            | errors count per service route and status code |
-| `<METRICS_NAMESPACE>.api.<routeId>.response_time`       | `timing`  | milliseconds                    | response time per service route                |
+| Name                                                                 | Type      | Unit of measure                 | Description                                    |
+| :------------------------------------------------------------------- | :-------- | :------------------------------ | :--------------------------------------------- |
+| `<METRICS_NAMESPACE>.process.cpu`                                    | `gauge`   | percentage                      | process cpu usage                              |
+| `<METRICS_NAMESPACE>.process.mem.external`                           | `gauge`   | bytes                           | process external memory                        |
+| `<METRICS_NAMESPACE>.process.mem.rss`                                | `gauge`   | bytes                           | process rss memory                             |
+| `<METRICS_NAMESPACE>.process.mem.heapUsed`                           | `gauge`   | bytes                           | process heap used memory                       |
+| `<METRICS_NAMESPACE>.process.mem.heapTotal`                          | `gauge`   | bytes                           | process heap total memory                      |
+| `<METRICS_NAMESPACE>.process.eventLoopDelay`                         | `gauge`   | milliseconds                    | process event loop delay                       |
+| `<METRICS_NAMESPACE>.process.eventLoopUtilization`                   | `gauge`   | absolute number between 0 and 1 | process event loop utilization                 |
+| `<METRICS_NAMESPACE>.<computedPrefix>.<routeId>.requests`            | `counter` | unit                            | requests count per service route               |
+| `<METRICS_NAMESPACE>.<computedPrefix>.<routeId>.errors.<statusCode>` | `counter` | unit                            | errors count per service route and status code |
+| `<METRICS_NAMESPACE>.<computedPrefix>.<routeId>.response_time`       | `timing`  | milliseconds                    | response time per service route                |
 
 ## Decorators
 
-The plugin adds the following decorators:
+The plugin adds some decorators to both the fastify instance and the reply object.
 
--   `fastify.stats`: A [dats](https://github.com/immobiliare/dats) instance
--   `fastify.doc`: A [doc](https://github.com/dnlup/doc) instance used to sample process metrics, if `options.collect.health` is `true
--   `fastify.hrtime2ns`: A utility function to convert the legacy `process.hrtime([time])` value to nanoseconds
--   `fastify.hrtime2ms`: A utility function to convert the legacy `process.hrtime([time])` value to milliseconds
--   `fastify.hrtime2s`: A utility function to convert the legacy `process.hrtime([time])` value to seconds
+### Fastify decorators
+
+##### `metricsNamespace`
+
+-   <`string`>
+
+The `namespace` passed to the plugin configuration option.
+
+#### `metricsRoutesPrefix`
+
+-   <`string`>
+
+The routes `prefix` passed to the `collect.routes.prefix` option.
+
+#### `metricsClient`
+
+The [Dats](https://github.com/immobiliare/dats) instance.
+
+#### `doc`
+
+The [doc](https://github.com/dnlup/doc) instance used to sample process metrics, if `options.collect.health` is `true`.
+
+#### `hrtime2ns`
+
+A utility function to convert the legacy `process.hrtime([time])` value to nanoseconds.
+
+See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2nstime).
+
+#### `hrtime2ms`
+
+A utility function to convert the legacy `process.hrtime([time])` value to milliseconds.
+
+See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2mstime).
+
+#### `hrtime2s`
+
+A utility function to convert the legacy `process.hrtime([time])` value to seconds.
+
+See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2stime).
+
+### Request and Reply decorators
+
+#### `sendTimingMetric(name[, value])`
+
+-   name <`string`>: the name of the metric
+-   value <`number`>: the value of the metric
+
+It sends a timing metric. It automatically prepends the route label to the passed `name`. It is just a small wrapper of the native `Dats` client method.
+
+#### `sendCounterMetric(name[, value])`
+
+-   name <`string`>: the name of the metric
+-   value <`number`>: the value of the metric
+
+It sends a counter metric. It automatically prepends the route label to the passed `name`. It is just a small wrapper of the native `Dats` client method.
+
+#### `sendGaugeMetric(name, value)`
+
+-   name <`string`>: the name of the metric
+-   value <`number`>: the value of the metric
+
+It sends a gauge metric. It automatically prepends the route label to the passed `name`. It is just a small wrapper of the native `Dats` client method.
+
+#### `sendSetMetric(name, value)`
+
+-   name <`string`>: the name of the metric
+-   value <`number`>: the value of the metric
+
+It sends a timing metric. It automatically prepends the route label to the passed `name`. It is just a small wrapper of the native `Dats` client method.
 
 ## Hooks
 
 The plugin uses the following hooks:
 
--   `onClose`: To close the [dats](https://github.com/immobiliare/dats) instance
--   `onRequest`: To count requests
--   `onResponse`: To measure response time
--   `onError`: To count errors
+-   `onRoute`: to generate the route labels at startup time if `collect.routes.mode` is set to `'static'`.
+-   `onClose`: to close the [Dats](https://github.com/immobiliare/dats) instance and the [sampler](https://github.com/dnlup/doc#new-docsampleroptions) instance.
+-   `onRequest`: it registers a hook to count requests and, if `collect.routes.mode` is set to `'dynamic'`, it adds another one to generate the route label.
+-   `onResponse`: to measure response time
+-   `onError`: to count errors
 
 ## API
 
@@ -132,20 +216,74 @@ This module exports a [plugin registration function](https://github.com/fastify/
 
 > The plugin is configured with an object with the following properties
 
--   `host`: String. [statsd](https://github.com/statsd/statsd) host. See [dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `namespace`: String. Metrics namespace. See [dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `bufferSize`: Number. Metrics buffer size. See [dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `bufferFlushTimeout`: Number. Metrics buffer flush timeout. See [dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `sampleInterval`: Number. Optional. Sample interval in `ms` used to gather process stats. Defaults to `1000`.
--   `onError`: Function: `(err) => void`. Optional. This function to handle possible Dats errors. See [dats](https://github.com/immobiliare/dats#new-clientoptions). Default: `(err) => log(err)`
--   `udpDnsCache`: Boolean. Optional. Activate udpDnsCache. See [dats](https://github.com/immobiliare/dats#new-clientoptions). Default `true`.
--   `udpDnsCacheTTL`: Number. Optional. See [dats](https://github.com/immobiliare/dats#new-clientoptions). DNS cache Time to live of an entry in seconds. Default `120`.
--   `customDatsClient`: Dats instance. Optional. The custom Dats client. If set, all fastify-metrics parameters of dats will not work.
+-   `host` <`string`> [statsd](https://github.com/statsd/statsd) host, see [Dats](https://github.com/immobiliare/dats#new-clientoptions).
+-   `namespace` <`string`> Metrics namespace, see [Dats](https://github.com/immobiliare/dats#new-clientoptions).
+-   `bufferSize` <`number`> Metrics buffer size, see [Dats](https://github.com/immobiliare/dats#new-clientoptions).
+-   `bufferFlushTimeout` <`number`> Metrics buffer flush timeout. See [Dats](https://github.com/immobiliare/dats#new-clientoptions).
+-   `sampleInterval` <`number`> Optional. The sample interval in `ms` used to gather process stats. It defaults to `1000`.
+-   `onError` <`Function`> Optional. This function to handle possible Dats errors (it takes the error as the only parameter). See [Dats](https://github.com/immobiliare/dats#new-clientoptions). Default: `(err) => log(err)`
+-   `udpDnsCache` <`boolean`> Optional. Activate udpDnsCache. See [Dats](https://github.com/immobiliare/dats#new-clientoptions). Default `true`.
+-   `udpDnsCacheTTL` <`number`> Optional. See [Dats](https://github.com/immobiliare/dats#new-clientoptions). DNS cache Time to live of an entry in seconds. Default `120`.
+-   `customDatsClient` [<`Client`>](https://github.com/immobiliare/dats#client). Optional. A custom Dats client. If set, all the `fastify-metrics` parameters of Dats will be ignored.
 -   `collect`: Object. Optional. Which metrics the plugin should track.
-    -   `collect.timings`: Boolean. Collect response timings (`<METRICS_NAMESPACE>.api.<routeId>`). Default: `true`.
-    -   `collect.hits`: Boolean. Collect requests count (`<METRICS_NAMESPACE>.api.requests.<routeId>`). Default: `true`.
-    -   `collect.errors`: Boolean. Collect errors count (`<METRICS_NAMESPACE>.api.errors.<routeId>.<statusCode>`). Default: `true`.
-    -   `collect.health`: Boolean. Collect process health data (`<METRICS_NAMESPACE>.process.*`). Default: `true`.
+    -   `routes` <`Object`>: routes metrics configuration
+        -   `mode` <`'static'`|`'dynamic'`> The strategy to generate the route metric label.
+        -   `prefix` <`string`> The prefix to use for the routes labels (`<METRICS_NAMESPACE>.<computedPrefix>.<routeId>.*`). It defaults to `''` (no prefix).
+        -   `getLabel` <`Function`> A custom function to generate the route label. It has a different signature depending on the mode. See []().
+        -   `timings`: Boolean. Collect response timings (`<METRICS_NAMESPACE>.<computedPrefix>.<routeId>`). Default: `true`.
+        -   `hits`: Boolean. Collect requests count (`<METRICS_NAMESPACE>.<computedPrefix>.requests.<routeId>`). Default: `true`.
+        -   `errors`: Boolean. Collect errors count (`<METRICS_NAMESPACE>.<computedPrefix>.errors.<routeId>.<statusCode>`). Default: `true`.
+    -   `health`: Boolean. Collect process health data (`<METRICS_NAMESPACE>.process.*`). Default: `true`.
+
+#### Routes labels generation modes
+
+There are two different mode to generate the label for each route that the plugin can see:
+
+-   `static`
+-   `dynamic`
+
+###### computedPrefix
+
+In both modes by default the plugin generates a prefix using:
+
+-   the [`fastify` prefix](https://www.fastify.io/docs/latest/Reference/Server/#prefix) used to register the plugin (`fastifyPrefix`)
+-   the routes prefix passed in the plugin option `collect.routes.prefix` (`routesPrefix`)
+
+Generating a computed prefix like this:
+
+`<fastifyPrefix>.<routesPrefix>`
+
+##### `static`
+
+In this mode a [`onRoute` hook](https://www.fastify.io/docs/latest/Reference/Hooks/#onroute) is registered in the `fastify` instance and the plugin generates a label at startup time combining the following strings:
+
+-   the [`fastify` prefix](https://www.fastify.io/docs/latest/Reference/Server/#prefix) used to register the plugin, accessible via the `prefix` key of the route registration options.
+-   the routes prefix passed in the plugin options, accessible as a parameter of the internal `getLabel` function.
+-   the `config.metrics.routeId` string used to configure the route, acessible via the `config` key of the route registration options.
+
+The `getLabel` function in this mode will have the following signature:
+
+###### `getLabel(prefix, options)`
+
+-   `prefix` <`string`> The plugin routes prefix value.
+-   `options` [<`Object`>](https://www.fastify.io/docs/latest/Reference/Hooks/#onroute) The route registration options.
+-   **Returns:** <`string`> The route label.
+
+##### `dynamic`
+
+In this mode a [`onRequest` hook](https://www.fastify.io/docs/latest/Reference/Hooks/#onrequest) is registerd in the `fastify` instance and the plugin generates a label and attaches it to each request and reply (the `metricsLabel` key) combining the following strings:
+
+-   the [`fastify` prefix](https://www.fastify.io/docs/latest/Reference/Server/#prefix) used to register the plugin, accessible via the `prefix` key of the `fastify` instance.
+-   the routes prefix passed in the plugin options, accessible via the `metricsRoutesPrefix` decorator of the `fastify` instance.
+-   the `config.metrics.routeId` string used to configure the route, acessible via the `config` key of the `request` or `reply` context.
+
+The `getLabel` function in this mode will have the following signature:
+
+###### `getLabel(request, reply)`
+
+-   `request`
+-   `reply`
+-   **Returns:** <`string`> The route label.
 
 ## Powered Apps
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,11 @@
-import { FastifyPluginCallback, FastifyPluginAsync } from 'fastify';
+import {
+    FastifyPluginCallback,
+    FastifyPluginAsync,
+    FastifyRequest,
+    FastifyReply,
+    FastifyInstance,
+    RouteOptions,
+} from 'fastify';
 
 import Client, { Options } from '@immobiliarelabs/dats';
 import { Sampler } from '@dnlup/doc';
@@ -8,13 +15,40 @@ type CustomClient = Pick<
     'gauge' | 'counter' | 'timing' | 'set' | 'close' | 'connect'
 >;
 
+type GetDynamicRouteLabel = (
+    this: FastifyInstance,
+    request: FastifyRequest,
+    reply: FastifyReply
+) => string;
+type GetStaticRouteLabel = (
+    prefix: string,
+    options: RouteOptions & { routePath: string; path: string; prefix: string }
+) => string;
+
+type CommonRouteOptions = {
+    prefix?: string;
+    timing?: boolean;
+    hits?: boolean;
+    errors?: boolean;
+};
+
+type DynamicMode = {
+    mode?: 'dynamic';
+    getLabel?: GetDynamicRouteLabel;
+} & CommonRouteOptions;
+
+type StaticMode = {
+    mode?: 'static';
+    getLabel?: GetStaticRouteLabel;
+} & CommonRouteOptions;
+
+type RoutesOptions = StaticMode | DynamicMode;
+
 export interface MetricsPluginOptions extends Options {
     sampleInterval?: number;
     collect?: {
-        timing: boolean;
-        hits: boolean;
-        errors: boolean;
-        health: boolean;
+        routes?: RoutesOptions;
+        health?: boolean;
     };
     customDatsClient?: CustomClient;
 }
@@ -23,13 +57,29 @@ export const MetricsPluginCallback: FastifyPluginCallback<MetricsPluginOptions>;
 export const MetricsPluginAsync: FastifyPluginAsync<MetricsPluginOptions>;
 
 export default MetricsPluginCallback;
-
 declare module 'fastify' {
     interface FastifyInstance {
-        stats: Client;
+        metricsRoutesPrefix: string;
+        metricsClient: Client;
         doc?: Sampler;
         hrtime2ns: (time: [number, number]) => number;
         hrtime2ms: (time: [number, number]) => number;
         hrtime2s: (time: [number, number]) => number;
+    }
+
+    interface FastifyRequest {
+        metricsLabel?: string;
+        sendTimingMetric: typeof Client.prototype.timing;
+        sendCounterMetric: typeof Client.prototype.counter;
+        sendGaugeMetric: (name: string, value: number) => void;
+        sendSetMetric: (name: string, value: number) => void;
+    }
+
+    interface FastifyReply {
+        metricsLabel?: string;
+        sendTimingMetric: typeof Client.prototype.timing;
+        sendCounterMetric: typeof Client.prototype.counter;
+        sendGaugeMetric: (name: string, value: number) => void;
+        sendSetMetric: (name: string, value: number) => void;
     }
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,12 @@
 import { expectType, expectError } from 'tsd';
 
-import Fastify, { FastifyPluginCallback, FastifyPluginAsync } from 'fastify';
+import Fastify, {
+    FastifyPluginCallback,
+    FastifyPluginAsync,
+    FastifyRequest,
+    FastifyReply,
+    FastifyInstance,
+} from 'fastify';
 import Client from '@immobiliarelabs/dats';
 import { Sampler } from '@dnlup/doc';
 import plugin, {
@@ -25,9 +31,90 @@ fastify.after((err) => {
     expectType<(time: [number, number]) => number>(fastify.hrtime2ms);
     expectType<(time: [number, number]) => number>(fastify.hrtime2ms);
     expectType<(time: [number, number]) => number>(fastify.hrtime2ms);
-    expectType<Client>(fastify.stats);
+    expectType<Client>(fastify.metricsClient);
     expectType<Sampler | undefined>(fastify.doc);
+    expectType<string>(fastify.metricsRoutesPrefix);
+
+    fastify.get('/', async function (request, reply) {
+        expectType<string | undefined>(request.metricsLabel);
+        expectType<typeof Client.prototype.timing>(request.sendTimingMetric);
+        expectType<typeof Client.prototype.counter>(request.sendCounterMetric);
+        expectType<
+            (name: string, value: number) => void
+        >(request.sendGaugeMetric);
+        expectType<
+            (name: string, value: number) => void
+        >(request.sendSetMetric);
+
+        expectType<string | undefined>(reply.metricsLabel);
+        expectType<typeof Client.prototype.timing>(reply.sendTimingMetric);
+        expectType<typeof Client.prototype.counter>(reply.sendCounterMetric);
+        expectType<
+            (name: string, value: number) => void
+        >(reply.sendGaugeMetric);
+        expectType<(name: string, value: number) => void>(reply.sendSetMetric);
+    });
 });
+
+expectError(
+    getFastify({
+        collect: {
+            routes: {
+                mode: 'nonexistent',
+            },
+        },
+    })
+);
+
+expectError(
+    getFastify({
+        collect: {
+            routes: {
+                mode: 'static',
+                getLabel: () => {},
+            },
+        },
+    })
+);
+
+expectError(
+    getFastify({
+        collect: {
+            routes: {
+                mode: 'static',
+                getLabel: () => {},
+            },
+        },
+    })
+);
+
+expectType(
+    getFastify({
+        collect: {
+            routes: {
+                mode: 'static',
+                getLabel: (prefix, options) =>
+                    `${prefix}.${options.routePath.replace('/', '.')}`,
+            },
+        },
+    })
+);
+
+expectType(
+    getFastify({
+        collect: {
+            routes: {
+                mode: 'dynamic',
+                getLabel: function (request, reply) {
+                    expectType<FastifyInstance>(this);
+                    expectType<FastifyRequest>(request);
+                    expectType<FastifyReply>(reply);
+                    return 'label';
+                },
+            },
+        },
+    })
+);
 
 expectError(
     getFastify({

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.onClose = function (instance, done) {
+    instance.doc && instance.doc.stop();
+    instance.metricsClient.close(done);
+};
+
+exports.onRequest = function (request, reply, next) {
+    request.sendCounterMetric('requests');
+    next();
+};
+
+exports.onResponse = function (request, reply, next) {
+    reply.sendTimingMetric('response_time', reply.getResponseTime());
+    next();
+};
+
+exports.onError = function (request, reply, error, done) {
+    request.sendCounterMetric(`errors.${reply.statusCode}`);
+    done();
+};

--- a/lib/routes/dynamic.js
+++ b/lib/routes/dynamic.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const {
+    getRouteId,
+    normalizeFastifyPrefix,
+    normalizeRoutePrefix,
+} = require('../util');
+
+exports.bindTimingMetric = function (client) {
+    return function (name, value, sampling) {
+        client.timing(`${this.metricsLabel}.${name}`, value, sampling);
+    };
+};
+
+exports.bindCounterMetric = function (client) {
+    return function (name, value, sampling) {
+        client.counter(`${this.metricsLabel}.${name}`, value, sampling);
+    };
+};
+
+exports.bindGaugeMetric = function (client) {
+    return function (name, value) {
+        client.gauge(`${this.metricsLabel}.${name}`, value);
+    };
+};
+
+exports.bindSetMetric = function (client) {
+    return function (name, value) {
+        client.set(`${this.metricsLabel}.${name}`, value);
+    };
+};
+
+exports.getLabel = function (request) {
+    const id = getRouteId(request.context.config);
+    const fastifyPrefix = normalizeFastifyPrefix(this.prefix);
+    const routePrefix = normalizeRoutePrefix(this.metricsRoutesPrefix);
+    return `${fastifyPrefix}${routePrefix}${id}`;
+};

--- a/lib/routes/static.js
+++ b/lib/routes/static.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const {
+    getRouteId,
+    normalizeRoutePrefix,
+    normalizeFastifyPrefix,
+} = require('../util');
+
+exports.bindTimingMetric = function (client) {
+    return function sendTimingMetric(name, value, sampling) {
+        client.timing(
+            `${this.context.config.metrics.label}.${name}`,
+            value,
+            sampling
+        );
+    };
+};
+exports.bindCounterMetric = function (client) {
+    return function sendCounterMetric(name, value, sampling) {
+        client.counter(
+            `${this.context.config.metrics.label}.${name}`,
+            value,
+            sampling
+        );
+    };
+};
+
+exports.bindGaugeMetric = function (client) {
+    return function sendGaugeMetric(name, value) {
+        client.gauge(`${this.context.config.metrics.label}.${name}`, value);
+    };
+};
+
+exports.bindSetMetric = function (client) {
+    return function sendSetMetric(name, value) {
+        client.set(`${this.context.config.metrics.label}.${name}`, value);
+    };
+};
+
+exports.getLabel = function (prefix, options) {
+    const id = getRouteId(options.config);
+    const fastifyPrefix = normalizeFastifyPrefix(options.prefix);
+    const routePrefix = normalizeRoutePrefix(prefix);
+    return `${fastifyPrefix}${routePrefix}${id}`;
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.getRouteId = function (config) {
+    const { metrics } = config;
+    return (metrics && metrics.routeId) || 'noId';
+};
+
+exports.normalizeFastifyPrefix = function (prefix) {
+    let normalized = prefix.replace(/\//g, '.');
+    if (normalized) {
+        // remove `.` at the beginning and add trailing `.`
+        normalized = `${normalized.slice(1)}.`;
+    }
+    return normalized;
+};
+
+exports.normalizeRoutePrefix = function (prefix) {
+    let routePrefix = prefix;
+    if (routePrefix) {
+        // add trailing `.`
+        routePrefix = `${routePrefix}.`;
+    }
+    return routePrefix;
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "files": [
         "index.js",
         "index.d.ts",
-        "util.js"
+        "util.js",
+        "lib"
     ],
     "scripts": {
         "lint": "eslint --fix --ignore-path .gitignore .",


### PR DESCRIPTION
Add a the possibility to pass a custom function to generate the route
label, introducing the "static" and "dynamic" mode for route labels generation.
Refactor tests.
Refactor routes metrics configuration.
Introduce a new naming convention for decorators that are not methods, which follows the pattern:
    
            metrics*
    
Add request and reply decorators to send metrics using the route label automatically.
    
**BREAKING CHANGE:** the routes metrics options have changed. The default route prefix is now an empty string and not 'api'. The dats instance is exported as `metricsCLient`.

Closes \#36 and starts to refactor config options \(\#54\).