### PR TITLE
feat(routes): add normalized strings to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It supports Fastify versions `>=3.0.0`.
         -   [Routes labels generation modes](#routes-labels-generation-modes)
             -   [computedPrefix](#computedprefix)
             *   [`static`](#static)
-                -   [`getLabel(prefix, options)`](#getlabelprefix-options)
+                -   [`getLabel(options)`](#getlabeloptions)
             *   [`dynamic`](#dynamic)
                 -   [`getLabel(request, reply)`](#getlabelrequest-reply)
 -   [Powered Apps](#powered-apps)
@@ -279,10 +279,14 @@ In this mode a [`onRoute` hook](https://www.fastify.io/docs/latest/Reference/Hoo
 
 The `getLabel` function in this mode will have the following signature:
 
-###### `getLabel(prefix, options)`
+###### `getLabel(options)`
 
--   `prefix` <`string`> The plugin routes prefix value.
--   `options` [<`Object`>](https://www.fastify.io/docs/latest/Reference/Hooks/#onroute) The route registration options.
+-   `options` [<`Object`>](https://www.fastify.io/docs/latest/Reference/Hooks/#onroute) The route registration
+    -   `config`
+        -   `metrics`
+            -   `routeId` <`string`>: the id used to initialize the route.
+            -   `fastifyPrefix` <`string`>: the normalized prefix of the fastify instance registering the route.
+            -   `routesPrefix` <`string`>: the normalized routes prefix passed to the plugin options.
 -   **Returns:** <`string`> The route label string without any `.` at the beginning or end.
 
 ##### `dynamic`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ It supports Fastify versions `>=3.0.0`.
         -   [`sendGaugeMetric(name, value)`](#sendgaugemetricname-value)
         -   [`sendSetMetric(name, value)`](#sendsetmetricname-value)
 -   [Hooks](#hooks)
+-   [Request and Reply context](#request-and-reply-context)
 -   [API](#api)
     -   [Configuration `options`](#configuration-options)
         -   [Routes labels generation modes](#routes-labels-generation-modes)
@@ -88,7 +89,9 @@ fastify.register(require('@immobiliarelabs/fastify-metrics'), {
 const route = {
     // This is required in order to associate a metric to a route
     config: {
-        routeId: 'root.getStatus',
+        metrics: {
+            routeId: 'root.getStatus',
+        },
     },
     url: '/',
     method: 'GET',
@@ -103,9 +106,12 @@ fastify.listen(3000);
 
 ### Notes
 
-The plugin uses the key `routeId` in the `config` object of the `Reply.context`. If none is found a default `noId` string is used.
+The plugin uses the key `routeId` in the `metrics` object of the `config` object in the `Request.context` or `Reply.context`. If none is found a default `noId` string is used.
 
-See https://github.com/fastify/fastify/blob/master/docs/Routes.md#config.
+See
+
+-   https://github.com/fastify/fastify/blob/master/docs/Routes.md#config
+-   [request and reply context](#request-and-reply-context)
 
 ## Metrics collected
 
@@ -208,6 +214,16 @@ The plugin uses the following hooks:
 -   `onResponse`: to measure response time
 -   `onError`: to count errors
 
+## Request and Reply context
+
+The plugin adds a `metrics` object to the context for convenience with the following properties:
+
+-   `routeId` <`string`>: the id for the current route
+-   `fastifyPrefix` <`string`>: the prefix of the fastify instance registering the route, with the `/` replaced with `.` and without the `.` at the beginning.
+-   `routesPrefix` <`string`>: the routes prefix passed to the plugin options and without `.` at the beginning and end.
+
+These properties can be useful when using a custom [`getLabel`](routes-labels-generation-modes) function.
+
 ## API
 
 This module exports a [plugin registration function](https://github.com/fastify/fastify/blob/master/docs/Plugins-Guide.md#register).
@@ -267,7 +283,7 @@ The `getLabel` function in this mode will have the following signature:
 
 -   `prefix` <`string`> The plugin routes prefix value.
 -   `options` [<`Object`>](https://www.fastify.io/docs/latest/Reference/Hooks/#onroute) The route registration options.
--   **Returns:** <`string`> The route label.
+-   **Returns:** <`string`> The route label string without any `.` at the beginning or end.
 
 ##### `dynamic`
 
@@ -283,7 +299,7 @@ The `getLabel` function in this mode will have the following signature:
 
 -   `request`
 -   `reply`
--   **Returns:** <`string`> The route label.
+-   **Returns:** <`string`> The route label string without any `.` at the beginning or end.
 
 The `this` context of the function is bound to the fastify instance of the request.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,8 +21,18 @@ type GetDynamicRouteLabel = (
     reply: FastifyReply
 ) => string;
 type GetStaticRouteLabel = (
-    prefix: string,
-    options: RouteOptions & { routePath: string; path: string; prefix: string }
+    options: RouteOptions & {
+        routePath: string;
+        path: string;
+        prefix: string;
+        config: {
+            metrics: {
+                routeId: string;
+                fastifyPrefix: string;
+                routesPrefix: string;
+            };
+        };
+    }
 ) => string;
 
 type CommonRouteOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,6 @@ declare module 'fastify' {
     }
 
     interface FastifyReply {
-        metricsLabel?: string;
         sendTimingMetric: typeof Client.prototype.timing;
         sendCounterMetric: typeof Client.prototype.counter;
         sendGaugeMetric: (name: string, value: number) => void;
@@ -85,7 +84,12 @@ declare module 'fastify' {
 
     interface FastifyContextConfig {
         metrics: {
+            /** The id for this route that will be used for the label */
             routeId: string;
+            /** The fastify prefix for this route */
+            fastifyPrefix: string;
+            /** The prefix the pugin should add for the registered routes */
+            routesPrefix: string;
         };
     }
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -38,7 +38,11 @@ fastify.after((err) => {
 
     fastify.get('/', async function (request, reply) {
         expectType<FastifyContextConfig>(request.context.config);
-        expectType<{ routeId: string }>(request.context.config.metrics);
+        expectType<{
+            routeId: string;
+            fastifyPrefix: string;
+            routesPrefix: string;
+        }>(request.context.config.metrics);
         expectType<string>(request.context.config.metrics.routeId);
         expectType<string | undefined>(request.metricsLabel);
         expectType<typeof Client.prototype.timing>(request.sendTimingMetric);
@@ -50,7 +54,6 @@ fastify.after((err) => {
             (name: string, value: number) => void
         >(request.sendSetMetric);
 
-        expectType<string | undefined>(reply.metricsLabel);
         expectType<typeof Client.prototype.timing>(reply.sendTimingMetric);
         expectType<typeof Client.prototype.counter>(reply.sendCounterMetric);
         expectType<

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -100,8 +100,8 @@ expectType(
         collect: {
             routes: {
                 mode: 'static',
-                getLabel: (prefix, options) =>
-                    `${prefix}.${options.routePath.replace('/', '.')}`,
+                getLabel: (options) =>
+                    `${options.config.metrics.fastifyPrefix}.${options.config.metrics.routesPrefix}.${options.config.metrics.routeId}`,
             },
         },
     })
@@ -115,7 +115,21 @@ expectType(
                 getLabel: function (request, reply) {
                     expectType<FastifyInstance>(this);
                     expectType<FastifyRequest>(request);
+                    expectType<string>(
+                        request.context.config.metrics.fastifyPrefix
+                    );
+                    expectType<string>(
+                        request.context.config.metrics.routesPrefix
+                    );
+                    expectType<string>(request.context.config.metrics.routeId);
                     expectType<FastifyReply>(reply);
+                    expectType<string>(
+                        reply.context.config.metrics.fastifyPrefix
+                    );
+                    expectType<string>(
+                        reply.context.config.metrics.routesPrefix
+                    );
+                    expectType<string>(reply.context.config.metrics.routeId);
                     return 'label';
                 },
             },

--- a/lib/routes/dynamic.js
+++ b/lib/routes/dynamic.js
@@ -1,38 +1,37 @@
 'use strict';
 
-const { getRouteId } = require('../util');
+const { kMetricsLabel } = require('../symbols');
 
 exports.bindTimingMetric = function (client) {
     return function (name, value, sampling) {
-        client.timing(`${this._metricsLabel}.${name}`, value, sampling);
+        client.timing(`${this[kMetricsLabel]}.${name}`, value, sampling);
     };
 };
 
 exports.bindCounterMetric = function (client) {
     return function (name, value, sampling) {
-        client.counter(`${this._metricsLabel}.${name}`, value, sampling);
+        client.counter(`${this[kMetricsLabel]}.${name}`, value, sampling);
     };
 };
 
 exports.bindGaugeMetric = function (client) {
     return function (name, value) {
-        client.gauge(`${this._metricsLabel}.${name}`, value);
+        client.gauge(`${this[kMetricsLabel]}.${name}`, value);
     };
 };
 
 exports.bindSetMetric = function (client) {
     return function (name, value) {
-        client.set(`${this._metricsLabel}.${name}`, value);
+        client.set(`${this[kMetricsLabel]}.${name}`, value);
     };
 };
 
 exports.getLabel = function (request) {
-    const id = getRouteId(request.context.config);
     const fastifyPrefix = request.context.config.metrics.fastifyPrefix
         ? `${request.context.config.metrics.fastifyPrefix}.`
         : request.context.config.metrics.fastifyPrefix;
     const routePrefix = request.context.config.metrics.routesPrefix
         ? `${request.context.config.metrics.routesPrefix}.`
         : request.context.config.metrics.routesPrefix;
-    return `${fastifyPrefix}${routePrefix}${id}`;
+    return `${fastifyPrefix}${routePrefix}${request.context.config.metrics.routeId}`;
 };

--- a/lib/routes/dynamic.js
+++ b/lib/routes/dynamic.js
@@ -1,38 +1,38 @@
 'use strict';
 
-const {
-    getRouteId,
-    normalizeFastifyPrefix,
-    normalizeRoutePrefix,
-} = require('../util');
+const { getRouteId } = require('../util');
 
 exports.bindTimingMetric = function (client) {
     return function (name, value, sampling) {
-        client.timing(`${this.metricsLabel}.${name}`, value, sampling);
+        client.timing(`${this._metricsLabel}.${name}`, value, sampling);
     };
 };
 
 exports.bindCounterMetric = function (client) {
     return function (name, value, sampling) {
-        client.counter(`${this.metricsLabel}.${name}`, value, sampling);
+        client.counter(`${this._metricsLabel}.${name}`, value, sampling);
     };
 };
 
 exports.bindGaugeMetric = function (client) {
     return function (name, value) {
-        client.gauge(`${this.metricsLabel}.${name}`, value);
+        client.gauge(`${this._metricsLabel}.${name}`, value);
     };
 };
 
 exports.bindSetMetric = function (client) {
     return function (name, value) {
-        client.set(`${this.metricsLabel}.${name}`, value);
+        client.set(`${this._metricsLabel}.${name}`, value);
     };
 };
 
 exports.getLabel = function (request) {
     const id = getRouteId(request.context.config);
-    const fastifyPrefix = normalizeFastifyPrefix(this.prefix);
-    const routePrefix = normalizeRoutePrefix(this.metricsRoutesPrefix);
+    const fastifyPrefix = request.context.config.metrics.fastifyPrefix
+        ? `${request.context.config.metrics.fastifyPrefix}.`
+        : request.context.config.metrics.fastifyPrefix;
+    const routePrefix = request.context.config.metrics.routesPrefix
+        ? `${request.context.config.metrics.routesPrefix}.`
+        : request.context.config.metrics.routesPrefix;
     return `${fastifyPrefix}${routePrefix}${id}`;
 };

--- a/lib/routes/static.js
+++ b/lib/routes/static.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const { getRouteId } = require('../util');
+const { kMetricsLabel } = require('../symbols');
 
 exports.bindTimingMetric = function (client) {
     return function sendTimingMetric(name, value, sampling) {
         client.timing(
-            `${this.context.config.metrics.label}.${name}`,
+            `${this.context.config.metrics[kMetricsLabel]}.${name}`,
             value,
             sampling
         );
@@ -14,7 +14,7 @@ exports.bindTimingMetric = function (client) {
 exports.bindCounterMetric = function (client) {
     return function sendCounterMetric(name, value, sampling) {
         client.counter(
-            `${this.context.config.metrics.label}.${name}`,
+            `${this.context.config.metrics[kMetricsLabel]}.${name}`,
             value,
             sampling
         );
@@ -23,23 +23,28 @@ exports.bindCounterMetric = function (client) {
 
 exports.bindGaugeMetric = function (client) {
     return function sendGaugeMetric(name, value) {
-        client.gauge(`${this.context.config.metrics.label}.${name}`, value);
+        client.gauge(
+            `${this.context.config.metrics[kMetricsLabel]}.${name}`,
+            value
+        );
     };
 };
 
 exports.bindSetMetric = function (client) {
     return function sendSetMetric(name, value) {
-        client.set(`${this.context.config.metrics.label}.${name}`, value);
+        client.set(
+            `${this.context.config.metrics[kMetricsLabel]}.${name}`,
+            value
+        );
     };
 };
 
-exports.getLabel = function (prefix, options) {
-    const id = getRouteId(options.config);
+exports.getLabel = function (options) {
     const fastifyPrefix = options.config.metrics.fastifyPrefix
         ? `${options.config.metrics.fastifyPrefix}.`
         : options.config.metrics.fastifyPrefix;
     const routePrefix = options.config.metrics.routesPrefix
         ? `${options.config.metrics.routesPrefix}.`
         : options.config.metrics.routesPrefix;
-    return `${fastifyPrefix}${routePrefix}${id}`;
+    return `${fastifyPrefix}${routePrefix}${options.config.metrics.routeId}`;
 };

--- a/lib/routes/static.js
+++ b/lib/routes/static.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const {
-    getRouteId,
-    normalizeRoutePrefix,
-    normalizeFastifyPrefix,
-} = require('../util');
+const { getRouteId } = require('../util');
 
 exports.bindTimingMetric = function (client) {
     return function sendTimingMetric(name, value, sampling) {
@@ -39,7 +35,11 @@ exports.bindSetMetric = function (client) {
 
 exports.getLabel = function (prefix, options) {
     const id = getRouteId(options.config);
-    const fastifyPrefix = normalizeFastifyPrefix(options.prefix);
-    const routePrefix = normalizeRoutePrefix(prefix);
+    const fastifyPrefix = options.config.metrics.fastifyPrefix
+        ? `${options.config.metrics.fastifyPrefix}.`
+        : options.config.metrics.fastifyPrefix;
+    const routePrefix = options.config.metrics.routesPrefix
+        ? `${options.config.metrics.routesPrefix}.`
+        : options.config.metrics.routesPrefix;
     return `${fastifyPrefix}${routePrefix}${id}`;
 };

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.kMetricsLabel = Symbol('fastify-metrics.metricsLabel');

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,20 +10,9 @@ exports.normalizeFastifyPrefix = function (prefix) {
         return prefix.replace(/\//g, '.').slice(1);
     }
     return prefix;
-    // let normalized = prefix.replace(/\//g, '.');
-    // if (normalized) {
-    //     // remove `.` at the beginning and add trailing `.`
-    //     normalized = `${normalized.slice(1)}.`;
-    // }
-    // return normalized;
 };
 
 exports.normalizeRoutePrefix = function (prefix) {
-    // let routePrefix = prefix;
-    // if (routePrefix) {
-    //     // add trailing `.`
-    //     routePrefix = `${routePrefix}.`;
-    // }
     let routePrefix = prefix.trim();
     return routePrefix;
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,19 +6,24 @@ exports.getRouteId = function (config) {
 };
 
 exports.normalizeFastifyPrefix = function (prefix) {
-    let normalized = prefix.replace(/\//g, '.');
-    if (normalized) {
-        // remove `.` at the beginning and add trailing `.`
-        normalized = `${normalized.slice(1)}.`;
+    if (prefix) {
+        return prefix.replace(/\//g, '.').slice(1);
     }
-    return normalized;
+    return prefix;
+    // let normalized = prefix.replace(/\//g, '.');
+    // if (normalized) {
+    //     // remove `.` at the beginning and add trailing `.`
+    //     normalized = `${normalized.slice(1)}.`;
+    // }
+    // return normalized;
 };
 
 exports.normalizeRoutePrefix = function (prefix) {
-    let routePrefix = prefix;
-    if (routePrefix) {
-        // add trailing `.`
-        routePrefix = `${routePrefix}.`;
-    }
+    // let routePrefix = prefix;
+    // if (routePrefix) {
+    //     // add trailing `.`
+    //     routePrefix = `${routePrefix}.`;
+    // }
+    let routePrefix = prefix.trim();
     return routePrefix;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@immobiliarelabs/fastify-metrics",
-            "version": "2.0.0-next.2",
+            "version": "2.0.0-next.3",
             "license": "MIT",
             "dependencies": {
                 "@dnlup/doc": "^3.1.0",

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -692,15 +692,17 @@ tap.test('metrics collection', async (t) => {
                     namespace: 'static_routes_custom_getlabel_test',
                     collect: {
                         routes: {
-                            getLabel: function (prefix, options) {
+                            getLabel: function (options) {
                                 t.ok(typeof options.prefix === 'string');
-                                t.ok(prefix === '');
+                                t.ok(options.config);
+                                t.ok(options.config.metrics);
+                                t.ok(
+                                    options.config.metrics.routesPrefix === ''
+                                );
                                 t.ok(options.method);
                                 t.ok(options.url);
                                 t.ok(options.path);
                                 t.ok(options.handler);
-                                t.ok(options.config);
-                                t.ok(options.config.metrics);
                                 return 'customLabel';
                             },
                         },
@@ -804,15 +806,18 @@ tap.test('metrics collection', async (t) => {
                     collect: {
                         routes: {
                             prefix: 'prefix',
-                            getLabel: function (prefix, options) {
+                            getLabel: function (options) {
                                 t.ok(typeof options.prefix === 'string');
-                                t.ok(prefix === 'prefix');
+                                t.ok(options.config);
+                                t.ok(options.config.metrics);
+                                t.ok(
+                                    options.config.metrics.routesPrefix ===
+                                        'prefix'
+                                );
                                 t.ok(options.method);
                                 t.ok(options.url);
                                 t.ok(options.path);
                                 t.ok(options.handler);
-                                t.ok(options.config);
-                                t.ok(options.config.metrics);
                                 return 'customLabel';
                             },
                         },


### PR DESCRIPTION
This should help because it already exposes the sanitised strings if you want to use your own `getLabel` function.