### PR TITLE
feat: scope instance decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ It supports Fastify versions `>=3.0.0`.
 -   [Metrics collected](#metrics-collected)
 -   [Decorators](#decorators)
     -   [Fastify decorators](#fastify-decorators)
-        -   [`metricsNamespace`](#metricsnamespace)
-        *   [`metricsRoutesPrefix`](#metricsroutesprefix)
-        *   [`metricsClient`](#metricsclient)
-        *   [`doc`](#doc)
-        *   [`hrtime2ns`](#hrtime2ns)
-        *   [`hrtime2ms`](#hrtime2ms)
-        *   [`hrtime2s`](#hrtime2s)
+        -   [`metrics`](#metrics)
+            -   [`metrics.namespace`](#metricsnamespace)
+            -   [`metrics.fastifyPrefix`](#metricsfastifyprefix)
+            -   [`metrics.routesPrefix`](#metricsroutesprefix)
+            -   [`metrics.client`](#metricsclient)
+            -   [`metrics.sampler`](#metricssampler)
+            -   [`metrics.hrtime2us`](#metricshrtime2us)
+            -   [`metrics.hrtime2ns`](#metricshrtime2ns)
+            -   [`metrics.hrtime2ms`](#metricshrtime2ms)
+            -   [`metrics.hrtime2s`](#metricshrtime2s)
     -   [Request and Reply decorators](#request-and-reply-decorators)
         -   [`sendTimingMetric(name[, value])`](#sendtimingmetricname-value)
         -   [`sendCounterMetric(name[, value])`](#sendcountermetricname-value)
@@ -136,39 +139,57 @@ The plugin adds some decorators to both the fastify instance and the reply objec
 
 ### Fastify decorators
 
-##### `metricsNamespace`
+#### `metrics`
+
+-   <`object`>
+
+An object containing the following properties:
+
+##### `metrics.namespace`
 
 -   <`string`>
 
 The `namespace` passed to the plugin configuration option.
 
-#### `metricsRoutesPrefix`
+##### `metrics.fastifyPrefix`
 
 -   <`string`>
 
-The routes `prefix` passed to the `collect.routes.prefix` option.
+The normalized fastify instance `prefix`.
 
-#### `metricsClient`
+##### `metrics.routesPrefix`
+
+-   <`string`>
+
+The normalized routes `prefix` passed to the `collect.routes.prefix` option.
+
+##### `metrics.client`
 
 The [Dats](https://github.com/immobiliare/dats) instance.
 
-#### `doc`
+##### `metrics.sampler`
 
-The [doc](https://github.com/dnlup/doc) instance used to sample process metrics, if `options.collect.health` is `true`.
+The [sampler](https://github.com/dnlup/doc) instance used to sample process metrics, if `options.collect.health` is `true`.
 
-#### `hrtime2ns`
+##### `metrics.hrtime2us`
+
+A utility function to convert the legacy `process.hrtime([time])` value to microseconds.
+
+See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2ustime).
+
+##### `metrics.hrtime2ns`
 
 A utility function to convert the legacy `process.hrtime([time])` value to nanoseconds.
 
 See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2nstime).
 
-#### `hrtime2ms`
+##### `metrics.hrtime2ms`
 
 A utility function to convert the legacy `process.hrtime([time])` value to milliseconds.
 
 See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2mstime).
 
-#### `hrtime2s`
+##### `metrics.hrtime2s`
 
 A utility function to convert the legacy `process.hrtime([time])` value to seconds.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,20 @@ type StaticMode = {
 
 type RoutesOptions = StaticMode | DynamicMode;
 
+type MetricsInstanceDecorator = {
+    namespace: string;
+    /** Normalized fastify prefix */
+    fastifyPrefix: string;
+    /** Normalized routes prefix */
+    routesPrefix: string;
+    client: Client;
+    sampler?: Sampler;
+    hrtime2us: (time: [number, number]) => number;
+    hrtime2ns: (time: [number, number]) => number;
+    hrtime2ms: (time: [number, number]) => number;
+    hrtime2s: (time: [number, number]) => number;
+};
+
 export interface MetricsPluginOptions extends Options {
     sampleInterval?: number;
     collect?: {
@@ -69,12 +83,7 @@ export const MetricsPluginAsync: FastifyPluginAsync<MetricsPluginOptions>;
 export default MetricsPluginCallback;
 declare module 'fastify' {
     interface FastifyInstance {
-        metricsRoutesPrefix: string;
-        metricsClient: Client;
-        doc?: Sampler;
-        hrtime2ns: (time: [number, number]) => number;
-        hrtime2ms: (time: [number, number]) => number;
-        hrtime2s: (time: [number, number]) => number;
+        metrics: MetricsInstanceDecorator;
     }
 
     interface FastifyRequest {
@@ -95,9 +104,9 @@ declare module 'fastify' {
         metrics: {
             /** The id for this route that will be used for the label */
             routeId: string;
-            /** The fastify prefix for this route */
+            /** Normalized fastify prefix for this route */
             fastifyPrefix: string;
-            /** The prefix the pugin should add for the registered routes */
+            /** Normalized prefix of the routes */
             routesPrefix: string;
         };
     }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -29,12 +29,14 @@ let fastify = getFastify();
 
 fastify.after((err) => {
     if (err) throw err;
-    expectType<(time: [number, number]) => number>(fastify.hrtime2ms);
-    expectType<(time: [number, number]) => number>(fastify.hrtime2ms);
-    expectType<(time: [number, number]) => number>(fastify.hrtime2ms);
-    expectType<Client>(fastify.metricsClient);
-    expectType<Sampler | undefined>(fastify.doc);
-    expectType<string>(fastify.metricsRoutesPrefix);
+    expectType<(time: [number, number]) => number>(fastify.metrics.hrtime2us);
+    expectType<(time: [number, number]) => number>(fastify.metrics.hrtime2ms);
+    expectType<(time: [number, number]) => number>(fastify.metrics.hrtime2ms);
+    expectType<(time: [number, number]) => number>(fastify.metrics.hrtime2ms);
+    expectType<Client>(fastify.metrics.client);
+    expectType<Sampler | undefined>(fastify.metrics.sampler);
+    expectType<string>(fastify.metrics.fastifyPrefix);
+    expectType<string>(fastify.metrics.routesPrefix);
 
     fastify.get('/', async function (request, reply) {
         expectType<FastifyContextConfig>(request.context.config);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,8 +1,8 @@
 'use strict';
 
 exports.onClose = function (instance, done) {
-    instance.doc && instance.doc.stop();
-    instance.metricsClient.close(done);
+    instance.metrics.sampler && instance.metrics.sampler.stop();
+    instance.metrics.client.close(done);
 };
 
 exports.onRequest = function (request, reply, next) {


### PR DESCRIPTION
Use a `metrics` object to scope instance decorators.

BREAKING CHANGE: the fastify instance decorators are exported in the `metrics` object.
The `doc` sampler instance is renamed to `sampler`.