### PR TITLE
fix: remove doc decorator

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,6 @@ module.exports = fp(
         let sampler;
         if (metricsConfig.health) {
             sampler = doc({ sampleInterval });
-            fastify.decorate('doc', sampler);
             const onSample = function () {
                 sendHealthData(
                     {


### PR DESCRIPTION
Remove `doc` decorator. It is not needed anymore since we moved everything under the `metrics` docorator object.