### PR TITLE
Change config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It supports Fastify versions `>=3.0.0`.
             -   [`metrics.hrtime2ms`](#metricshrtime2ms)
             -   [`metrics.hrtime2s`](#metricshrtime2s)
     -   [Request and Reply decorators](#request-and-reply-decorators)
+        -   [`getMetricLabel()`](#getmetriclabel)
         -   [`sendTimingMetric(name[, value])`](#sendtimingmetricname-value)
         -   [`sendCounterMetric(name[, value])`](#sendcountermetricname-value)
         -   [`sendGaugeMetric(name, value)`](#sendgaugemetricname-value)
@@ -197,6 +198,10 @@ See [hrtime-utils](https://github.com/dnlup/hrtime-utils#hrtime2stime).
 
 ### Request and Reply decorators
 
+#### `getMetricLabel()`
+
+-   **Returns** <`string`>: the computed metric label of the route.
+
 #### `sendTimingMetric(name[, value])`
 
 -   name <`string`>: the name of the metric
@@ -253,24 +258,17 @@ This module exports a [plugin registration function](https://github.com/fastify/
 
 > The plugin is configured with an object with the following properties
 
--   `host` <`string`> [statsd](https://github.com/statsd/statsd) host, see [Dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `namespace` <`string`> Metrics namespace, see [Dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `bufferSize` <`number`> Metrics buffer size, see [Dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `bufferFlushTimeout` <`number`> Metrics buffer flush timeout. See [Dats](https://github.com/immobiliare/dats#new-clientoptions).
--   `sampleInterval` <`number`> Optional. The sample interval in `ms` used to gather process stats. It defaults to `1000`.
--   `onError` <`Function`> Optional. This function to handle possible Dats errors (it takes the error as the only parameter). See [Dats](https://github.com/immobiliare/dats#new-clientoptions). Default: `(err) => log(err)`
--   `udpDnsCache` <`boolean`> Optional. Activate udpDnsCache. See [Dats](https://github.com/immobiliare/dats#new-clientoptions). Default `true`.
--   `udpDnsCacheTTL` <`number`> Optional. See [Dats](https://github.com/immobiliare/dats#new-clientoptions). DNS cache Time to live of an entry in seconds. Default `120`.
--   `customDatsClient` [<`Client`>](https://github.com/immobiliare/dats#client). Optional. A custom Dats client. If set, all the `fastify-metrics` parameters of Dats will be ignored.
--   `collect`: Object. Optional. Which metrics the plugin should track.
-    -   `routes` <`Object`>: routes metrics configuration
-        -   `mode` <`'static'`|`'dynamic'`> The strategy to generate the route metric label.
-        -   `prefix` <`string`> The prefix to use for the routes labels (`<METRICS_NAMESPACE>.<computedPrefix>.<routeId>.*`). It defaults to `''` (no prefix).
-        -   `getLabel` <`Function`> A custom function to generate the route label. It has a different signature depending on the mode. See []().
-        -   `timings`: Boolean. Collect response timings (`<METRICS_NAMESPACE>.<computedPrefix>.<routeId>`). Default: `true`.
-        -   `hits`: Boolean. Collect requests count (`<METRICS_NAMESPACE>.<computedPrefix>.requests.<routeId>`). Default: `true`.
-        -   `errors`: Boolean. Collect errors count (`<METRICS_NAMESPACE>.<computedPrefix>.errors.<routeId>.<statusCode>`). Default: `true`.
-    -   `health`: Boolean. Collect process health data (`<METRICS_NAMESPACE>.process.*`). Default: `true`.
+-   `client` <`Object`|`Client`> The statsd client [configuration](https://github.com/immobiliare/dats#new-clientoptions) object or a [`Client`](https://github.com/immobiliare/dats) instance. When using the options object, a default `onError` function is used to log with level `error` the event with the app logger.
+-   `routes` <`Object`> Routes metrics configuration
+    -   `mode` <`'static'`|`'dynamic'`> The [strategy](#routes-labels-generation-modes) to generate the route metric label.
+    -   `prefix` <`string`> The prefix to use for the routes labels (`<METRICS_NAMESPACE>.<computedPrefix>.<routeId>.*`). It defaults to `''` (no prefix).
+    -   `getLabel` <`Function`> A custom function to generate the route label. It has a different signature depending on the [mode](#routes-labels-generation-modes).
+    -   `timings` <`boolean`> Collect response timings (`<METRICS_NAMESPACE>.<computedPrefix>.<routeId>`). Default: `true`.
+    -   `hits` <`boolean`> Collect requests count (`<METRICS_NAMESPACE>.<computedPrefix>.requests.<routeId>`). Default: `true`.
+    -   `errors` <`boolean`> Collect errors count (`<METRICS_NAMESPACE>.<computedPrefix>.errors.<routeId>.<statusCode>`). Default: `true`.
+-   `health` <`boolean`|`Object`> Flag to enable/disable the collection of the process health data(`<METRICS_NAMESPACE>.process.*`) or an object to configure a subset of the health metrics provided by the [sampler](https://github.com/dnlup/doc#new-docsampleroptions). Default: `true`.
+    -   `sampleInterval` <`number`> The number of milliseconds of the interval to get the metrics sample.
+    -   `eventLoopOptions` <`Object`> The options object used to configure the core [`monitorEventLoopDelay`](https://nodejs.org/docs/latest-v16.x/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions).
 
 #### Routes labels generation modes
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ import {
     RouteOptions,
 } from 'fastify';
 
-import Client, { Options } from '@immobiliarelabs/dats';
+import Client, { Options as ClientOptions } from '@immobiliarelabs/dats';
 import { Sampler } from '@dnlup/doc';
 
 type CustomClient = Pick<
@@ -54,6 +54,13 @@ type StaticMode = {
 
 type RoutesOptions = StaticMode | DynamicMode;
 
+type SamplerOptions = {
+    sampleInterval?: number;
+    eventLoopOptions?: {
+        resolution: number;
+    };
+};
+
 type MetricsInstanceDecorator = {
     namespace: string;
     /** Normalized fastify prefix */
@@ -68,13 +75,10 @@ type MetricsInstanceDecorator = {
     hrtime2s: (time: [number, number]) => number;
 };
 
-export interface MetricsPluginOptions extends Options {
-    sampleInterval?: number;
-    collect?: {
-        routes?: RoutesOptions;
-        health?: boolean;
-    };
-    customDatsClient?: CustomClient;
+export interface MetricsPluginOptions {
+    client?: ClientOptions | CustomClient;
+    routes?: RoutesOptions;
+    health?: boolean | SamplerOptions;
 }
 
 export const MetricsPluginCallback: FastifyPluginCallback<MetricsPluginOptions>;

--- a/index.js
+++ b/index.js
@@ -119,8 +119,7 @@ module.exports = fp(
         }
 
         let stats;
-        // If client is a custom client or is not an options object
-        if (client instanceof Client || isCustomClient(client)) {
+        if (isCustomClient(client)) {
             for (const method of STATSD_METHODS) {
                 const fn = client[method];
                 if (!fn || typeof fn !== 'function')

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -62,73 +62,57 @@ fastify.after((err) => {
 
 expectError(
     getFastify({
-        collect: {
-            routes: {
-                mode: 'nonexistent',
-            },
+        routes: {
+            mode: 'nonexistent',
         },
     })
 );
 
 expectError(
     getFastify({
-        collect: {
-            routes: {
-                mode: 'static',
-                getLabel: () => {},
-            },
+        routes: {
+            mode: 'static',
+            getLabel: () => {},
         },
     })
 );
 
 expectError(
     getFastify({
-        collect: {
-            routes: {
-                mode: 'static',
-                getLabel: () => {},
-            },
+        routes: {
+            mode: 'static',
+            getLabel: () => {},
         },
     })
 );
 
 expectType(
     getFastify({
-        collect: {
-            routes: {
-                mode: 'static',
-                getLabel: (options) =>
-                    `${options.config.metrics.fastifyPrefix}.${options.config.metrics.routesPrefix}.${options.config.metrics.routeId}`,
-            },
+        routes: {
+            mode: 'static',
+            getLabel: (options) =>
+                `${options.config.metrics.fastifyPrefix}.${options.config.metrics.routesPrefix}.${options.config.metrics.routeId}`,
         },
     })
 );
 
 expectType(
     getFastify({
-        collect: {
-            routes: {
-                mode: 'dynamic',
-                getLabel: function (request, reply) {
-                    expectType<FastifyInstance>(this);
-                    expectType<FastifyRequest>(request);
-                    expectType<string>(
-                        request.context.config.metrics.fastifyPrefix
-                    );
-                    expectType<string>(
-                        request.context.config.metrics.routesPrefix
-                    );
-                    expectType<string>(request.context.config.metrics.routeId);
-                    expectType<FastifyReply>(reply);
-                    expectType<string>(
-                        reply.context.config.metrics.fastifyPrefix
-                    );
-                    expectType<string>(
-                        reply.context.config.metrics.routesPrefix
-                    );
-                    expectType<string>(reply.context.config.metrics.routeId);
-                    return 'label';
-                },
+        routes: {
+            mode: 'dynamic',
+            getLabel: function (request, reply) {
+                expectType<FastifyInstance>(this);
+                expectType<FastifyRequest>(request);
+                expectType<string>(
+                    request.context.config.metrics.fastifyPrefix
+                );
+                expectType<string>(request.context.config.metrics.routesPrefix);
+                expectType<string>(request.context.config.metrics.routeId);
+                expectType<FastifyReply>(reply);
+                expectType<string>(reply.context.config.metrics.fastifyPrefix);
+                expectType<string>(reply.context.config.metrics.routesPrefix);
+                expectType<string>(reply.context.config.metrics.routeId);
+                return 'label';
             },
         },
     })
@@ -136,7 +120,7 @@ expectType(
 
 expectError(
     getFastify({
-        customDatsClient: {
+        client: {
             counter: () => {},
             set: () => {},
             timing: () => {},
@@ -147,12 +131,12 @@ expectError(
     })
 );
 
-const customDatsClient = new Client({ host: 'localhost' });
+const client = new Client({ host: 'localhost' });
 
-expectType(getFastify({ customDatsClient }));
+expectType(getFastify({ client }));
 expectType(
     getFastify({
-        customDatsClient: {
+        client: {
             counter: () => {},
             set: () => {},
             timing: () => {},

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { default: Dats } = require('@immobiliarelabs/dats');
+
 exports.getRouteId = function (config) {
     const { metrics } = config;
     return (metrics && metrics.routeId) || 'noId';
@@ -27,6 +29,7 @@ exports.STATSD_METHODS = [
 ];
 
 exports.isCustomClient = function (obj) {
+    if (obj instanceof Dats) return true;
     for (const key of exports.STATSD_METHODS) {
         if (typeof obj[key] === 'function') {
             return true;

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,10 +27,10 @@ exports.STATSD_METHODS = [
 ];
 
 exports.isCustomClient = function (obj) {
-    for (const key in obj) {
+    for (const key of exports.STATSD_METHODS) {
         if (typeof obj[key] === 'function') {
             return true;
         }
-        return false;
     }
+    return false;
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,3 +16,21 @@ exports.normalizeRoutePrefix = function (prefix) {
     let routePrefix = prefix.trim();
     return routePrefix;
 };
+
+exports.STATSD_METHODS = [
+    'counter',
+    'timing',
+    'gauge',
+    'set',
+    'close',
+    'connect',
+];
+
+exports.isCustomClient = function (obj) {
+    for (const key in obj) {
+        if (typeof obj[key] === 'function') {
+            return true;
+        }
+        return false;
+    }
+};

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -3,6 +3,7 @@
 const tap = require('tap');
 const fastify = require('fastify');
 const { Sampler } = require('@dnlup/doc');
+const { default: Dats } = require('@immobiliarelabs/dats');
 const sinon = require('sinon');
 const { StatsdMock } = require('./helpers/statsd');
 const StatsdMockTCP = require('./helpers/statsdTCP');
@@ -207,6 +208,10 @@ tap.test('configuration validation', async (t) => {
         });
 
         t.ok(stub.called);
+
+        t.resolves(
+            setup({ client: new Dats({ host: 'udp://localhost:7000' }) })
+        );
     });
 
     t.test(


### PR DESCRIPTION
Move client, health and routes configuration at the top level of the config object, each with their own key.

Closes #54 