### PR TITLE
Rename timing option

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -45,7 +45,7 @@ fastify.register(require('@immobiliarelabs/fastify-metrics'), {
     sampleInterval: 1000,
     collect: {
         hits: true,
-        timings: true,
+        timing: true,
         errors: true,
         health: true,
     },
@@ -76,14 +76,14 @@ fastify.register(require('@immobiliarelabs/fastify-metrics'), {
 });
 ```
 
-#### `routes` metric
+#### `routes` metrics
 
 ```js
 const fastify = require('fastify')();
 
 fastify.register(require('@immobiliarelabs/fastify-metrics'), {
     routes: {
-        timings: true,
+        responseTime: true,
         hits: true,
         errors: true,
     },

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,9 +37,9 @@ type GetStaticRouteLabel = (
 
 type CommonRouteOptions = {
     prefix?: string;
-    timing?: boolean;
     hits?: boolean;
     requestSize?: boolean;
+    responseTime?: boolean;
     responseSize?: boolean;
     errors?: boolean;
 };

--- a/index.js
+++ b/index.js
@@ -58,22 +58,21 @@ const DEFAULT_CONFIG_OPTIONS = {
         mode: 'static',
         prefix: '',
         /**
-         * Response time
-         * TODO: rename in responseTime
+         * Route hit counter
          */
-        timing: true,
-        /**
-         * Route response size
-         */
-        responseSize: false,
+        hits: true,
         /**
          * Route request size
          */
         requestSize: false,
         /**
-         * Route hit counter
+         * Response time
          */
-        hits: true,
+        responseTime: true,
+        /**
+         * Route response size
+         */
+        responseSize: false,
         /**
          * Route errors counter
          */
@@ -101,10 +100,10 @@ module.exports = fp(
         };
 
         for (const key of [
-            'timing',
-            'responseSize',
-            'requestSize',
             'hits',
+            'requestSize',
+            'responseTime',
+            'responseSize',
             'errors',
         ]) {
             if (typeof config.routes[key] !== 'boolean') {
@@ -229,7 +228,7 @@ module.exports = fp(
         if (config.routes.hits) {
             fastify.addHook('onRequest', hooks.onRequest);
         }
-        if (config.routes.timing) {
+        if (config.routes.responseTime) {
             fastify.addHook('onResponse', hooks.onResponse);
         }
         if (config.routes.errors) {

--- a/tests/configuration.test.js
+++ b/tests/configuration.test.js
@@ -84,10 +84,10 @@ tap.test('invalid options', async (t) => {
         {
             value: {
                 routes: {
-                    timing: 'true',
+                    responseTime: 'true',
                 },
             },
-            message: '"timing" must be a boolean.',
+            message: '"responseTime" must be a boolean.',
         },
         {
             value: {

--- a/tests/metrics-collection.test.js
+++ b/tests/metrics-collection.test.js
@@ -137,15 +137,15 @@ tap.test('disabling process health metrics', async (t) => {
     ]);
 });
 
-tap.test('disabling routes timings metric', async (t) => {
+tap.test('disabling routes responseTime metric', async (t) => {
     const server = await setupRoutes(
         {
             client: {
                 host: `udp://127.0.0.1:${t.context.address.port}`,
-                namespace: 'disable_routes_timings_test',
+                namespace: 'disable_routes_responseTime_test',
             },
             routes: {
-                timing: false,
+                responseTime: false,
             },
         },
         routes,
@@ -162,17 +162,17 @@ tap.test('disabling routes timings metric', async (t) => {
         }),
         new Promise((resolve) => {
             const regexes = [
-                /disable_routes_timings_test\.noId\.requests:1\|c/,
-                /disable_routes_timings_test\.process\.mem\.external:\d+(\.\d+)?\|g/,
-                /disable_routes_timings_test\.process\.mem\.rss:\d+(\.\d+)?\|g/,
-                /disable_routes_timings_test\.process\.mem\.heapUsed:\d+(\.\d+)?\|g/,
-                /disable_routes_timings_test\.process\.mem\.heapTotal:\d+(\.\d+)?\|g/,
-                /disable_routes_timings_test\.process\.eventLoopDelay:\d+(\.\d+)?\|g/,
-                /disable_routes_timings_test\.process\.eventLoopUtilization:\d+(\.\d+)?\|g/,
-                /disable_routes_timings_test\.process\.cpu:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.noId\.requests:1\|c/,
+                /disable_routes_responseTime_test\.process\.mem\.external:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.process\.mem\.rss:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.process\.mem\.heapUsed:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.process\.mem\.heapTotal:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.process\.eventLoopDelay:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.process\.eventLoopUtilization:\d+(\.\d+)?\|g/,
+                /disable_routes_responseTime_test\.process\.cpu:\d+(\.\d+)?\|g/,
             ];
             const notExpected =
-                /disable_routes_timings_test\.noId:\d+(\.\d+)?\|ms/;
+                /disable_routes_responseTime_test\.noId:\d+(\.\d+)?\|ms/;
             let cursor = 0;
             t.context.statsd.on('metric', (buffer) => {
                 const metric = buffer.toString();
@@ -348,7 +348,7 @@ tap.test('disabling all default metrics', async (t) => {
                 namespace: 'disabling_all_metrics_test',
             },
             routes: {
-                timing: false,
+                responseTime: false,
                 hits: false,
                 errors: false,
             },


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

The `timing` option is renamed to `responseTime` to be consisten with the other routes metrics names.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
