### PR TITLE
fix(types): fix cannot cast MetricsPluginOptions properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ type GetDynamicRouteLabel = (
     request: FastifyRequest,
     reply: FastifyReply
 ) => string;
+
 type GetStaticRouteLabel = (
     options: RouteOptions & {
         routePath: string;
@@ -54,8 +55,6 @@ type StaticMode = {
     getLabel?: GetStaticRouteLabel;
 } & CommonRouteOptions;
 
-type RoutesOptions = StaticMode | DynamicMode;
-
 type SamplerOptions = {
     sampleInterval?: number;
     eventLoopOptions?: {
@@ -79,9 +78,11 @@ type MetricsInstanceDecorator = {
 
 export interface MetricsPluginOptions {
     client?: ClientOptions | CustomClient;
-    routes?: boolean | RoutesOptions;
+    routes?: boolean | StaticMode | DynamicMode;
     health?: boolean | SamplerOptions;
 }
+
+export { ClientOptions, CustomClient, StaticMode, DynamicMode, SamplerOptions };
 
 export const MetricsPluginCallback: FastifyPluginCallback<MetricsPluginOptions>;
 export const MetricsPluginAsync: FastifyPluginAsync<MetricsPluginOptions>;


### PR DESCRIPTION
Closes https://github.com/immobiliare/fastify-metrics/issues/150

## 🚨 Proposed changes

This should fix issue https://github.com/immobiliare/fastify-metrics/issues/150
I exported also types for the other properties of MetricsPluginOptions that has pipe definition

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
