### PR TITLE
fix: skip getLabel on 404

### DIFF
--- a/examples/nesting.js
+++ b/examples/nesting.js
@@ -34,7 +34,7 @@ app.register(plugin, {
         host: `udp://127.0.0.1:${udpPort}`,
         namespace: 'nesting_upd_test',
     },
-    routes: false
+    routes: false,
 });
 
 app.register(

--- a/index.js
+++ b/index.js
@@ -225,7 +225,11 @@ module.exports = fp(
             fastify.decorateRequest(kMetricsLabel, '');
             fastify.decorateReply(kMetricsLabel, '');
             fastify.addHook('onRequest', function (request, reply, next) {
-                const label = getLabel.call(this, request, reply);
+                // For some reason, this request.is404 is false on 404s only in tests.
+                /* istanbul ignore next */
+                const label = request.is404
+                    ? ''
+                    : getLabel.call(this, request, reply);
                 request[kMetricsLabel] = label;
                 reply[kMetricsLabel] = label;
                 next();

--- a/tests/dynamic-mode.test.js
+++ b/tests/dynamic-mode.test.js
@@ -410,25 +410,25 @@ tap.test('custom getLabel and custom prefix', async (t) => {
         app,
         t
     );
+});
 
-    tap.test('404 test', async (t) => {
-        const server = await setup(
-            {
-                client: {
-                    namespace: '404_dynamic_mode_errors',
-                },
-                health: false,
+tap.test('404 test', async (t) => {
+    const server = await setup(
+        {
+            client: {
+                namespace: '404_dynamic_mode_errors',
             },
-            undefined,
-            t
-        );
-        t.teardown(async () => {
-            return server.close();
-        });
-        const response = await server.inject({
-            method: 'GET',
-            url: '/not-existing',
-        });
-        t.equal(404, response.statusCode);
+            health: false,
+        },
+        undefined,
+        t
+    );
+    t.teardown(async () => {
+        return server.close();
     });
+    const response = await server.inject({
+        method: 'GET',
+        url: '/not-existingasdfasdfasdfasdfasdfasdfasd',
+    });
+    t.equal(404, response.statusCode);
 });


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.
`getLabel` was being called on 404s causing errors and 500 responses.
Strangely we had a test for it, but the `fastify` app seems to behave differently when using inject and the test was passing anyway.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
