### PR TITLE
Fix: trace 500 status code in metrics for 400 response

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -32,8 +32,16 @@ exports.onResponseSize = function (request, reply, payload, next) {
 };
 
 exports.onError = function (request, reply, error, done) {
+    let code = undefined;
     /* istanbul ignore next */
-    const code = reply.statusCode < 400 ? 500 : reply.statusCode;
+    if (!reply.statusCode || reply.statusCode === 200) {
+        // reply has 200 statusCode by default with fastify 4 so we need to check and retrieve the status code of the Error object.
+        // @see https://github.com/fastify/fastify/issues/4501
+        code = error.statusCode || error.status || 500;
+    } else {
+        code = reply.statusCode < 400 ? 500 : reply.statusCode;
+    }
+
     request.sendCounterMetric(`errors.${code}`);
     done();
 };


### PR DESCRIPTION


## 🚨 Proposed changes

Due to changes with Fastify 4, the default value for reply.statusCode is 200 so the current implementation of the `onError` hook send 500 to metrics server.

This PR fix this behaviour by sending error.statusCode when available if the reply.statusCode is 200 or undefined.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
