### PR TITLE
Fastify V5 routeConfig deprecation Fix

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,8 +33,8 @@ const metrics = reply.context.config.metrics;
 ### V5
 
 ```js
-const metrics = request.routeConfig.metrics;
-const metrics = reply.request.routeConfig.metrics;
+const metrics = request.routeOptions.config.metrics;
+const metrics = reply.request.routeOptions.config.metrics;
 ```
 
 # Migrating from v1 to v2

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ There are more usage examples in the [`examples`](./examples) folder.
 
 ### Note
 
-The plugin internally uses the `routeId` key in the `metrics` object of the `Request.routeConfig` or `Reply.request.routeConfig` object to build the label of the metric of a route.
+The plugin internally uses the `routeId` key in the `metrics` object of the `Request.routeOptions.config` or `Reply.request.routeOptions.config` object to build the label of the metric of a route.
 
 See
 
@@ -275,7 +275,7 @@ The plugin uses the following hooks:
 
 ## Request and Reply routeConfig
 
-The plugin adds a `metrics` object to the `Request.routeConfig` and `Reply.request.routeConfig` for convenience with the following properties:
+The plugin adds a `metrics` object to the `Request.routeOptions.config` and `Reply.request.routeOptions.config` for convenience with the following properties:
 
 -   `routeId` <`string`> The id for the current route
 -   `fastifyPrefix` <`string`> The prefix of the fastify instance registering the route, with the `/` replaced with `.` and without the `.` at the beginning.
@@ -379,7 +379,7 @@ await fastify.register(require('@immobiliarelabs/fastify-metrics'), {
         mode: 'dynamic',
         getLabel: function (request, reply) {
             const auth = request.user ? 'user' : 'anonim';
-            const { metrics } = request.routeConfig.config;
+            const { metrics } = request.routeOptions.config.config;
             const routesPrefix = metrics.routesPrefix
                 ? `${metrics.routesPrefix}.`
                 : '';

--- a/examples/dynamic_mode.js
+++ b/examples/dynamic_mode.js
@@ -37,8 +37,7 @@ app.register(plugin, {
     routes: {
         mode: 'dynamic',
         getLabel(request) {
-            const { metrics } = request.routeConfig;
-            const { routeId, fastifyPrefix, routesPrefix } = metrics;
+            const { routeId, fastifyPrefix, routesPrefix } = request.routeOptions.config.metrics;
             const type = request.headers['x-type'] || 'default';
             return `${fastifyPrefix ? fastifyPrefix + '.' : ''}${
                 routesPrefix ? routesPrefix + '.' : ''

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -54,13 +54,13 @@ fastify.after((err) => {
     fastify.get('/', async function (request, reply) {
         expectType<
             FastifyContextConfig & FastifyRouteConfig
-        >(request.routeConfig);
+        >(request.routeOptions.config);
         expectType<{
             routeId: string;
             fastifyPrefix?: string;
             routesPrefix?: string;
-        }>(request.routeConfig.metrics);
-        expectType<string>(request.routeConfig.metrics.routeId);
+        }>(request.routeOptions.config.metrics);
+        expectType<string>(request.routeOptions.config.metrics.routeId);
         expectType<typeof Client.prototype.timing>(request.sendTimingMetric);
         expectType<typeof Client.prototype.counter>(request.sendCounterMetric);
         expectType<typeof Client.prototype.gauge>(request.sendGaugeMetric);
@@ -119,20 +119,20 @@ expectType(
                 expectType<FastifyInstance>(this);
                 expectType<FastifyRequest>(request);
                 expectType<string | undefined>(
-                    request.routeConfig.metrics.fastifyPrefix
+                    request.routeOptions.config.metrics.fastifyPrefix
                 );
                 expectType<string | undefined>(
-                    request.routeConfig.metrics.routesPrefix
+                    request.routeOptions.config.metrics.routesPrefix
                 );
-                expectType<string>(request.routeConfig.metrics.routeId);
+                expectType<string>(request.routeOptions.config.metrics.routeId);
                 expectType<FastifyReply>(reply);
                 expectType<string | undefined>(
-                    reply.request.routeConfig.metrics.fastifyPrefix
+                    reply.request.routeOptions.config.metrics.fastifyPrefix
                 );
                 expectType<string | undefined>(
-                    reply.request.routeConfig.metrics.routesPrefix
+                    reply.request.routeOptions.config.metrics.routesPrefix
                 );
-                expectType<string>(reply.request.routeConfig.metrics.routeId);
+                expectType<string>(reply.request.routeOptions.config.metrics.routeId);
                 return 'label';
             },
         },

--- a/lib/routes/dynamic.js
+++ b/lib/routes/dynamic.js
@@ -40,11 +40,8 @@ exports.decorators = {
 };
 
 exports.getLabel = function (request) {
-    const fastifyPrefix = request.routeConfig.metrics.fastifyPrefix
-        ? `${request.routeConfig.metrics.fastifyPrefix}.`
-        : request.routeConfig.metrics.fastifyPrefix;
-    const routePrefix = request.routeConfig.metrics.routesPrefix
-        ? `${request.routeConfig.metrics.routesPrefix}.`
-        : request.routeConfig.metrics.routesPrefix;
-    return `${fastifyPrefix}${routePrefix}${request.routeConfig.metrics.routeId}`;
+    const { routeId, fastifyPrefix, routesPrefix } = request.routeOptions.config.metrics
+    const r  =`${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`
+    console.log(r)
+    return r;
 };

--- a/lib/routes/dynamic.js
+++ b/lib/routes/dynamic.js
@@ -40,8 +40,6 @@ exports.decorators = {
 };
 
 exports.getLabel = function (request) {
-    const { routeId, fastifyPrefix, routesPrefix } = request.routeOptions.config.metrics
-    const r  =`${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`
-    console.log(r)
-    return r;
+    const { routeId, fastifyPrefix, routesPrefix } = request.routeOptions.config.metrics;
+    return `${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`;
 };

--- a/lib/routes/static.js
+++ b/lib/routes/static.js
@@ -45,8 +45,6 @@ exports.decorators = {
 };
 
 exports.getLabel = function (options) {
-    const { routeId, fastifyPrefix, routesPrefix } = options.config.metrics
-    const r  =`${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`
-    console.log(r)
-    return r;
+    const { routeId, fastifyPrefix, routesPrefix } = options.config.metrics;
+    return `${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`;
 };

--- a/lib/routes/static.js
+++ b/lib/routes/static.js
@@ -35,21 +35,18 @@ exports.decorators = {
     getMetricLabel: function bindGetRouteLabel(type) {
         if (type === 'reply') {
             return function () {
-                return this.request.routeConfig.metrics[kMetricsLabel];
+                return this.request.routeOptions.config.metrics[kMetricsLabel];
             };
         }
         return function () {
-            return this.routeConfig.metrics[kMetricsLabel];
+            return this.routeOptions.config.metrics[kMetricsLabel];
         };
     },
 };
 
 exports.getLabel = function (options) {
-    const fastifyPrefix = options.config.metrics.fastifyPrefix
-        ? `${options.config.metrics.fastifyPrefix}.`
-        : options.config.metrics.fastifyPrefix;
-    const routePrefix = options.config.metrics.routesPrefix
-        ? `${options.config.metrics.routesPrefix}.`
-        : options.config.metrics.routesPrefix;
-    return `${fastifyPrefix}${routePrefix}${options.config.metrics.routeId}`;
+    const { routeId, fastifyPrefix, routesPrefix } = options.config.metrics
+    const r  =`${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`
+    console.log(r)
+    return r;
 };

--- a/lib/routes/util.js
+++ b/lib/routes/util.js
@@ -6,15 +6,14 @@ exports.shouldSkip = (requestOrReply) => {
         return !(
             config.metrics &&
             config.metrics.routeId
-        )
+        );
     } else {
-        console.log('no config')
-        const config = requestOrReply.request.routeOptions.config
+        const config = requestOrReply.request.routeOptions.config;
         return !(
             config &&
             config.metrics &&
             config.routeId
-        )
+        );
         
     }
 };

--- a/lib/routes/util.js
+++ b/lib/routes/util.js
@@ -1,15 +1,20 @@
 'use strict';
 
 exports.shouldSkip = (requestOrReply) => {
-    return requestOrReply.routeConfig
-        ? !(
-              requestOrReply.routeConfig &&
-              requestOrReply.routeConfig.metrics &&
-              requestOrReply.routeConfig.metrics.routeId
-          )
-        : !(
-              requestOrReply.request.routeConfig &&
-              requestOrReply.request.routeConfig.metrics &&
-              requestOrReply.request.routeConfig.metrics.routeId
-          );
+    const config = requestOrReply.routeOptions.config;
+    if (config) {
+        return !(
+            config.metrics &&
+            config.metrics.routeId
+        )
+    } else {
+        console.log('no config')
+        const config = requestOrReply.request.routeOptions.config
+        return !(
+            config &&
+            config.metrics &&
+            config.routeId
+        )
+        
+    }
 };

--- a/lib/routes/util.js
+++ b/lib/routes/util.js
@@ -1,19 +1,10 @@
 'use strict';
 
 exports.shouldSkip = (requestOrReply) => {
-    const config = requestOrReply.routeOptions.config;
-    if (config) {
-        return !(
-            config.metrics &&
-            config.metrics.routeId
-        );
+    const routeOptions = requestOrReply.routeOptions;
+    if (routeOptions) {
+        return !routeOptions.metrics?.routeId
     } else {
-        const config = requestOrReply.request.routeOptions.config;
-        return !(
-            config &&
-            config.metrics &&
-            config.routeId
-        );
-        
+        return !requestOrReply.request.routeOptions?.config?.metrics?.routeId
     }
 };

--- a/tests/dynamic-mode.test.js
+++ b/tests/dynamic-mode.test.js
@@ -196,8 +196,8 @@ tap.test('custom getLabel', async (t) => {
                     t.ok(typeof this.prefix === 'string');
                     t.ok(typeof this.metrics.routesPrefix === 'string');
                     for (const r of [
-                        request.routeConfig,
-                        reply.request.routeConfig,
+                        request.routeOptions.config,
+                        reply.request.routeOptions.config,
                     ]) {
                         t.ok(typeof r.metrics === 'object');
                         t.equal('string', typeof r.metrics.routeId);
@@ -304,8 +304,8 @@ tap.test('custom getLabel and custom prefix', async (t) => {
                     t.ok(typeof this.prefix === 'string');
                     t.ok(this.metrics.routesPrefix === 'prefix');
                     for (const r of [
-                        request.routeConfig,
-                        reply.request.routeConfig,
+                        request.routeOptions.config,
+                        reply.request.routeOptions.config,
                     ]) {
                         t.ok(typeof r.metrics === 'object');
                         t.equal('string', typeof r.metrics.routeId);

--- a/tests/helpers/utils.js
+++ b/tests/helpers/utils.js
@@ -37,16 +37,11 @@ function addRoutes(app, routes) {
 async function defaultSetup(opts = {}, cb, t, prefix = '/static/test') {
     if (!cb) {
         cb = (req, res) => {
-            const fastifyPrefix = req.routeConfig.metrics.fastifyPrefix
-                ? `${req.routeConfig.metrics.fastifyPrefix}.`
-                : req.routeConfig.metrics.fastifyPrefix;
-            const routePrefix = req.routeConfig.metrics.routesPrefix
-                ? `${req.routeConfig.metrics.routesPrefix}.`
-                : req.routeConfig.metrics.routesPrefix;
+            const { routeId, fastifyPrefix, routesPrefix } = req.routeOptions.config.metrics
             t.equal(req.getMetricLabel(), res.getMetricLabel());
             t.equal(
                 req.getMetricLabel(),
-                `${fastifyPrefix}${routePrefix}${req.routeConfig.metrics.routeId}`
+                `${fastifyPrefix ? `${fastifyPrefix}.` : ''}${routesPrefix ? `${routesPrefix}.` : ''}${routeId}`
             );
         };
     }


### PR DESCRIPTION
## 🚨 Proposed changes

Simply replaced the routeConfig with routeOptions.config to fix the Fasitfy V5 routeConfig deprecation (https://github.com/immobiliare/fastify-metrics/issues/519). And some refactoring for the functions generating the metics label.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [x] Refactor
