### PR TITLE
feat: switch to fastify v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]
-                node-version: [18.x, 20.x]
+                node-version: [20.x, 22.x]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v4

--- a/benchmarks/fixtures/base.js
+++ b/benchmarks/fixtures/base.js
@@ -27,7 +27,7 @@ service.get(
     }
 );
 
-service.listen(3000, (error) => {
+service.listen({ port: 3000 }, (error) => {
     if (error) {
         service.log.error(error);
         process.exit(1);

--- a/benchmarks/fixtures/withDynamicModeMetrics.js
+++ b/benchmarks/fixtures/withDynamicModeMetrics.js
@@ -43,7 +43,7 @@ service.get(
     }
 );
 
-service.listen(3002, (error) => {
+service.listen({ port: 3002 }, (error) => {
     if (error) {
         service.log.error(error);
         process.exit(1);

--- a/benchmarks/fixtures/withStaticModeMetrics.js
+++ b/benchmarks/fixtures/withStaticModeMetrics.js
@@ -38,7 +38,7 @@ service.get(
     }
 );
 
-service.listen(3001, (error) => {
+service.listen({ port: 3001 }, (error) => {
     if (error) {
         service.log.error(error);
         process.exit(1);

--- a/index.js
+++ b/index.js
@@ -264,6 +264,6 @@ module.exports = fp(
     },
     {
         name: '@immobiliarelabs/fastify-metrics',
-        fastify: '>=4.x',
+        fastify: '^5.0.0',
     }
 );

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,7 +19,7 @@ import { FastifyRouteConfig } from 'fastify/types/route';
 
 function getFastify(options?: MetricsPluginOptions) {
     const instance = Fastify();
-    return instance.register(plugin, options);
+    return instance.register(plugin, options || {});
 }
 
 expectType<FastifyPluginCallback<MetricsPluginOptions>>(plugin);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -11,7 +11,7 @@ exports.onRequest = function (request, reply, next) {
 };
 
 exports.onResponse = function (request, reply, next) {
-    reply.sendTimingMetric('response_time', reply.getResponseTime());
+    reply.sendTimingMetric('response_time', reply.elapsedTime);
     next();
 };
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "license": "MIT",
     "engines": {
-        "node": ">=18"
+        "node": ">=20"
     },
     "devDependencies": {
         "@commitlint/cli": "^18.4.3",
@@ -66,7 +66,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.0.0-alpha.2",
-        "fastify": "^4.25.1",
+        "fastify": "^5.1.0",
         "husky": "^8.0.0",
         "is-ci": "^3.0.0",
         "lint-staged": "^15.2.0",
@@ -81,10 +81,9 @@
         "@dnlup/doc": "^5.0.3",
         "@dnlup/hrtime-utils": "^1.0.1",
         "@immobiliarelabs/dats": "^5.1.0",
-        "fastify-plugin": "^4.0.0"
+        "fastify-plugin": "^5.0.1"
     },
     "volta": {
-        "node": "18.15.0",
-        "npm": "9.6.2"
+        "node": "20.18.1"
     }
 }


### PR DESCRIPTION
Migrate plugin to fastify 5

BREAKING CHANGE: fastify 4 is not supported anymore and minumum required Node.js version is 20.

## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

[[Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.]]

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
